### PR TITLE
feat(app): support for boolean values in map and env loaders

### DIFF
--- a/env_loader.go
+++ b/env_loader.go
@@ -37,6 +37,12 @@ func (prefix EnvLoader) Load(node reflect.Value, tag tagData) (reflect.Value, er
 			return reflect.Value{}, errInvalidValue(tag, prefix)
 		}
 		return reflect.ValueOf(intVal), nil
+	case reflect.Bool:
+		var boolVal bool = false
+		if strings.ToLower(val) == "true" {
+			boolVal = true
+		}
+		return reflect.ValueOf(boolVal), nil
 	default:
 		return reflect.Value{}, errValueNotSupported(tag, prefix)
 	}

--- a/env_loader_test.go
+++ b/env_loader_test.go
@@ -41,6 +41,7 @@ func TestEnvLoader(t *testing.T) {
 	t.Setenv("CONFIG_FIELDB", "10")
 	t.Setenv("CONFIG_FIELDD_FIELDE", "world")
 	t.Setenv("CONFIG_FIELD_H", "x")
+	t.Setenv("CONFIG_FIELD_I", "true")
 
 	expected := RootType{
 		FieldA: "hello",
@@ -49,6 +50,7 @@ func TestEnvLoader(t *testing.T) {
 			FieldE: "world",
 		},
 		FieldH: "x",
+		FieldI: true,
 	}
 	assert.NoError(LoadConfig(
 		out,

--- a/gonk_test.go
+++ b/gonk_test.go
@@ -23,6 +23,7 @@ type RootType struct {
 	FieldF []IntermediateB `config:"fieldF,optional"`
 	FieldG string          `config:"-"`
 	FieldH string
+	FieldI bool
 }
 
 func TestMultiLoader(t *testing.T) {
@@ -39,6 +40,7 @@ func TestMultiLoader(t *testing.T) {
 			{FieldG: "baz"},
 		},
 		FieldH: "bin",
+		FieldI: true,
 	}
 
 	t.Setenv("CONFIG_FIELDB", "10")
@@ -53,6 +55,7 @@ func TestMultiLoader(t *testing.T) {
 		},
 		"field-g": "don't look at me",
 		"field-h": "bin",
+		"field-i": true,
 	})
 	envLoader := EnvLoader("config")
 	assert.NoError(LoadConfig(out, mapLoader, envLoader, nil))

--- a/map_loader.go
+++ b/map_loader.go
@@ -14,7 +14,7 @@ func (m MapLoader) Load(node reflect.Value, tag tagData) (reflect.Value, error) 
 		return reflect.Value{}, errValueNotPresent(tag, m)
 	}
 	switch node.Kind() {
-	case reflect.String, reflect.Int:
+	case reflect.String, reflect.Int, reflect.Bool:
 		out = reflect.ValueOf(val)
 	case reflect.Struct:
 		out = reflect.New(node.Type()).Elem()

--- a/map_loader_test.go
+++ b/map_loader_test.go
@@ -80,6 +80,7 @@ func TestMapLoader(t *testing.T) {
 			{FieldG: "baz"},
 		},
 		FieldH: "-",
+		FieldI: true,
 	}
 
 	inp := MapLoader(map[string]any{
@@ -93,6 +94,7 @@ func TestMapLoader(t *testing.T) {
 			map[string]any{"fieldG": "baz"},
 		},
 		"field-h": "-",
+		"field-i": true,
 	})
 	assert.NoError(LoadConfig(out, inp))
 	assert.Equal(expected, *out)


### PR DESCRIPTION
adds support for the boolean data type in map and environmnent loaders. Required values must be exported as either true or false in all cases for environment. Praying that the yaml parser can properly handle setting boolean values (sure it can)
!patch